### PR TITLE
remove unnecessary dependency on Distances

### DIFF
--- a/src/ImageDistances.jl
+++ b/src/ImageDistances.jl
@@ -2,10 +2,7 @@ __precompile__()
 
 module ImageDistances
 
-import Base: size, ==
-
 using Distances
-import Distances: evaluate, colwise, pairwise
 
 using Colors
 using ProgressMeter
@@ -19,6 +16,11 @@ export
     ImagePreMetric,
     ImageSemiMetric,
     ImageMetric,
+
+    # generic functions
+    evaluate,
+    colwise,
+    pairwise,
 
     # concrete types
     Hausdorff,

--- a/src/hausdorff.jl
+++ b/src/hausdorff.jl
@@ -46,7 +46,7 @@ function evaluate_pset(d::Hausdorff, psetA, psetB)
     psetA == psetB && return 0.
     (isempty(psetA) || isempty(psetA)) && return Inf
 
-    D = pairwise(Euclidean(), psetA, psetB)
+    D = Distances.pairwise(Euclidean(), psetA, psetB)
 
     dAB = reduce(d.inner_op, minimum(D, dims=2))
     dBA = reduce(d.inner_op, minimum(D, dims=1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,12 @@
 using Colors
-using Distances
 using ImageDistances
 using LinearAlgebra: I, issymmetric
 using Test
 
 # define a dummy distance to test generic
 # colwise and pairwise (coverage purposes)
-import ImageDistances: evaluate
 struct MyImgDist <: ImageMetric end
-evaluate(d::MyImgDist, imgA, imgB) = π
+ImageDistances.evaluate(d::MyImgDist, imgA, imgB) = π
 
 @testset "ImageDistances.jl" begin
     @testset "Generic" begin


### PR DESCRIPTION
1. `import evaluate, pairwise, colwise` is unnecessary since we are not overriding the existing methods -- we are writing new methods( e.g., `pairwise(d::ImageMetric, imgA, imgB)`) 
2. `export evaluate, pairwise, colwise` as is done in `Distances.jl`. [see here](https://github.com/JuliaStats/Distances.jl/blob/0167683d5fddf7814e473ec4a6b8c07a6956fccc/src/Distances.jl#L14-L20)
2. We don't need to `using Distances` in the  test code. --> Previous one is a little ambiguous; which `colwise` is called in `ds = colwise(MyImgDist(), imgs, imgs)`? [see here](https://github.com/JuliaImages/ImageDistances.jl/blob/1f378e0c6557c9ec4db64622104aeaa484ca14e8/test/runtests.jl#L15)