### PR TITLE
support ndarray (fixes #24)

### DIFF
--- a/src/hausdorff.jl
+++ b/src/hausdorff.jl
@@ -83,7 +83,7 @@ const ModifiedHausdorff = GenericHausdorff{MeanReduction, MaxReduction}
 ModifiedHausdorff() = ModifiedHausdorff(MeanReduction(), MaxReduction())
 
 # convert binary image to a point set format
-function img2pset(img::Gray2dImage{Bool})
+function img2pset(img::GenericGrayImage{Bool})
     inds = findall(x->x==true, img)
     [inds[j][i] for i=1:ndims(img), j=1:length(inds)]
 end
@@ -101,20 +101,20 @@ function evaluate_pset(d::GenericHausdorff, psetA, psetB)
     _reduce(d.outer_op, (dAB, dBA))
 end
 
-evaluate(d::GenericHausdorff, imgA::Gray2dImage{Bool}, imgB::Gray2dImage{Bool}) =
+evaluate(d::GenericHausdorff, imgA::GenericGrayImage{Bool}, imgB::GenericGrayImage{Bool}) =
     evaluate_pset(d, img2pset(imgA), img2pset(imgB))
 
 # helper functions
 @doc (@doc Hausdorff)
-hausdorff(imgA::Gray2dImage{Bool}, imgB::Gray2dImage{Bool}) = evaluate(Hausdorff(), imgA, imgB)
+hausdorff(imgA::GenericGrayImage{Bool}, imgB::GenericGrayImage{Bool}) = evaluate(Hausdorff(), imgA, imgB)
 
 @doc (@doc ModifiedHausdorff)
-modified_hausdorff(imgA::Gray2dImage{Bool}, imgB::Gray2dImage{Bool}) = evaluate(ModifiedHausdorff(), imgA, imgB)
+modified_hausdorff(imgA::GenericGrayImage{Bool}, imgB::GenericGrayImage{Bool}) = evaluate(ModifiedHausdorff(), imgA, imgB)
 
 # precalculate psets to accelerate computing
 function pairwise(d::GenericHausdorff,
-                  imgsA::AbstractVector{Gray2dImage{Bool}},
-                  imgsB::AbstractVector{Gray2dImage{Bool}})
+                  imgsA::AbstractVector{GenericGrayImage{Bool}},
+                  imgsB::AbstractVector{GenericGrayImage{Bool}})
     psetsA = [img2pset(imgA) for imgA in imgsA]
     psetsB = [img2pset(imgB) for imgB in imgsB]
 
@@ -137,7 +137,7 @@ function pairwise(d::GenericHausdorff,
     D
 end
 
-function pairwise(d::GenericHausdorff, imgs::AbstractVector{Gray2dImage{Bool}})
+function pairwise(d::GenericHausdorff, imgs::AbstractVector{GenericGrayImage{Bool}})
     psets = [img2pset(img) for img in imgs]
 
     n = length(imgs)

--- a/test/ciede2000.jl
+++ b/test/ciede2000.jl
@@ -3,13 +3,16 @@
     dist = CIEDE2000()
 
     sz_img = (3,3)
+    sz_img_3 = (3, 3, 3)
     m, n = 3, 5
+
     type_list = generate_test_types([Bool, Float32, N0f8], [Gray])
     A = [0 0 0; 1 1 1; 0 0 0]
     B = [1 1 1; 0 0 0; 1 1 1]
     for T in type_list
         @testset "$T" begin
             test_SemiMetric(dist, sz_img, T)
+            test_ndarray(dist, sz_img_3, T)
             test_colwise(dist, n, sz_img, T)
             test_pairwise(dist, m, n, sz_img, T)
 
@@ -33,6 +36,7 @@
     for T in type_list
         a = A .|> T
         b = B .|> T
+        test_ndarray(dist, sz_img_3, T)
         test_numeric(dist, a, b, T; filename="references/CIEDE2000_2d_Color3")
     end
     test_cross_type(dist, A, B, type_list)

--- a/test/hausdorff.jl
+++ b/test/hausdorff.jl
@@ -4,6 +4,7 @@ A = [true false false
      false false true]
 B = copy(A); B[1,2] = true;
 sz_img = (3,3)
+sz_img_3 = (3, 3, 3)
 m, n = 3, 5
 
 type_list = generate_test_types([Bool], [Gray])
@@ -16,6 +17,7 @@ type_list = generate_test_types([Bool], [Gray])
         for T in type_list
             @testset "$T" begin
                 test_Metric(dist, sz_img, T)
+                test_ndarray(dist, sz_img_3, T)
                 test_colwise(dist, n, sz_img, T)
                 test_pairwise(dist, m, n, sz_img, T)
 
@@ -32,6 +34,7 @@ type_list = generate_test_types([Bool], [Gray])
         for T in type_list
             @testset "$T" begin
                 test_SemiMetric(dist, sz_img, T)
+                test_ndarray(dist, sz_img_3, T)
                 test_colwise(dist, n, sz_img, T)
                 test_pairwise(dist, m, n, sz_img, T)
 

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -1,6 +1,7 @@
 # Test Metrics from Distances.jl
 m, n = 3, 5
 sz_img = (3, 3)
+sz_img_3 = (3, 3, 3)
 
 dist_list = [SqEuclidean(),
             Euclidean(),
@@ -21,6 +22,7 @@ for dist in dist_list
             @testset "$T" begin
                 test_colwise(dist, n, sz_img, T)
                 test_pairwise(dist, m, n, sz_img, T)
+                test_ndarray(dist, sz_img_3, T)
 
                 a = A .|> T
                 b = B .|> T
@@ -42,6 +44,7 @@ for dist in dist_list
             @testset "$T" begin
                 test_colwise(dist, n, sz_img, T)
                 test_pairwise(dist, m, n, sz_img, T)
+                test_ndarray(dist, sz_img_3, T)
 
                 a = A .|> T
                 b = B .|> T

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -134,3 +134,12 @@ function test_SemiMetric(d, sz, T)
     @test evaluate(d, x, x) ≈ 0
     @test evaluate(d, x, y) ≈ evaluate(d, y, x)
 end
+
+function test_ndarray(d, sz, T)
+    x = rand(T, sz)
+    y = rand(T, sz)
+    @test_nowarn evaluate(d, x, y)
+
+    T <: AbstractGray || return nothing
+    @test evaluate(d, x, y) == evaluate(d, channelview(x), channelview(y))
+end


### PR DESCRIPTION
`Abstract{<:Number, N}` is treated as Gray N-dimensional Image

* Hausdorff distances now support N-d Bool image inputs
* add ndarray test coverage to other distances which already support ndarray image inputs

cc: @juliohm