### PR TITLE
ambiguity patches

### DIFF
--- a/src/metrics_distances.jl
+++ b/src/metrics_distances.jl
@@ -70,3 +70,15 @@ for (ATa, ATb) in ((AbstractGray, AbstractGray),
         end
     end
 end
+
+# WeightedEuclidean defines its own method of colwise!
+function colwise!(r::AbstractVector, dist::WeightedEuclidean,
+                a::AbstractMatrix{<:GenericImage},
+                b::AbstractMatrix{<:GenericImage})
+    (m, n) = get_colwise_dims(r, a, b)
+    m == 1 || throw(DimensionMismatch("The number of columns should be 1."))
+    @inbounds for j = 1:n
+        r[j] = dist(a[1,j], b[1,j]) # TODO: use view
+    end
+    r
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,10 @@ using ImageCore
 using IterTools
 using ReferenceTests
 using ImageDistances
+using Distances
+
+# there're still two ambiguities on colwise! for SqMahalanobis and Mahalanobisat
+@test length(detect_ambiguities(Distances, ImageDistances)) == 2
 
 # general distances should cover any combination of number_types and color_types unless it's special designed
 include("testutils.jl")


### PR DESCRIPTION
Before this patch there're 32 ambiguities, of which:

* ✅ 29 belong to `result_type` for metrics that are not yet tested and imported by ImageDistances. 
* ✅ 1 belong to `colwise!` for `WeightEuclidean` that can be solved with one method definition. 
* ❌ 2 belong to `colwise!` for `SqMahalanobis` and `Mahalanobisat` that can't be solved easily (at least in this repo).