### PR TITLE
Optimized Hausdorff and ModifiedHausdorff algorithms (fixes #56).

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 ColorVectorSpace = "0.7, 0.8"
 Distances = "0.8.1, 0.9.2, 0.10"
 ImageCore = "0.8.6"
+ImageMorphology = "0.2"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.9"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageMorphology = "787d08f9-d448-5407-9aad-5290dd7ab264"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 

--- a/src/ImageDistances.jl
+++ b/src/ImageDistances.jl
@@ -14,6 +14,9 @@ import Distances:
 using ImageCore, ColorVectorSpace
 using ImageCore.MappedArrays
 using ImageCore: GenericImage, GenericGrayImage, Pixel
+using ImageMorphology.FeatureTransform:
+    feature_transform,
+    distance_transform
 
 # FixedPoint and Bool are promoted to Float before evaluate
 const PromoteType = Union{FixedPoint,Bool}

--- a/src/hausdorff.jl
+++ b/src/hausdorff.jl
@@ -92,8 +92,9 @@ function evaluate_hausdorff(d::GenericHausdorff,
                             dtA::AbstractArray,
                             dtB::AbstractArray)
     # trivial cases
-    imgA == imgB && return 0.
-    (isempty(imgA) || isempty(imgB)) && return Inf
+    T = result_type(d, dtA, dtB)
+    imgA == imgB && return zero(T)
+    (isempty(imgA) || isempty(imgB)) && return convert(T, Inf)
 
     # dtA and dtB contain the distance from each pixel
     # to the nearest active pixel in imgA and imgB, respectively.

--- a/src/hausdorff.jl
+++ b/src/hausdorff.jl
@@ -101,8 +101,8 @@ function evaluate_hausdorff(d::GenericHausdorff,
     # We only care about the distances from imgA to imgB and vice
     # versa, so we'll pull those out by using those images as logical
     # masks into the distance arrays.
-    dAB = _reduce(d.inner_op, dtB[imgA])
-    dBA = _reduce(d.inner_op, dtA[imgB])
+    dAB = _reduce(d.inner_op, view(dtB, imgA))
+    dBA = _reduce(d.inner_op, view(dtA, imgB))
     _reduce(d.outer_op, (dAB, dBA))
 end
 function evaluate_hausdorff(d::GenericHausdorff,

--- a/src/hausdorff.jl
+++ b/src/hausdorff.jl
@@ -1,4 +1,11 @@
 """
+    BoolImage
+
+A type representing a binary image.
+"""
+const BoolImage = AbstractArray{Bool}
+
+"""
     ReductionOperation
 
 A reduction operation on a set of values (e.g. maximum).
@@ -83,34 +90,55 @@ const ModifiedHausdorff = GenericHausdorff{MeanReduction, MaxReduction}
 ModifiedHausdorff() = ModifiedHausdorff(MeanReduction(), MaxReduction())
 
 # convert binary image to a point set format
-function img2pset(img::AbstractArray{T}) where T<:Union{Gray{Bool}, Bool}
-    inds = findall(x->x==true, img)
-    [inds[j][i] for i=1:ndims(img), j=1:length(inds)]
+function img2dt(img::BoolImage)
+    distance_transform(feature_transform(img))
 end
-function img2pset(img::GenericGrayImage)
+function img2dt(img::GenericGrayImage)
     try
-        return img2pset(of_eltype(Bool, img))
+        return img2dt(of_eltype(Bool, img))
     catch e
         e isa InexactError && throw(ArgumentError("Binary image is needed."))
         rethrow(e)
     end
 end
 
-function evaluate_pset(d::GenericHausdorff, psetA, psetB)
+function evaluate_dt(   d::GenericHausdorff,
+                        imgA::BoolImage,
+                        imgB::BoolImage,
+                        dtA::AbstractArray,
+                        dtB::AbstractArray)
     # trivial cases
-    psetA == psetB && return 0.
-    (isempty(psetA) || isempty(psetA)) && return Inf
+    imgA == imgB && return 0.
+    (isempty(imgA) || isempty(imgB)) && return Inf
 
-    D = pairwise(Euclidean(), psetA, psetB, dims=2)
-
-    dAB = _reduce(d.inner_op, minimum(D, dims=2))
-    dBA = _reduce(d.inner_op, minimum(D, dims=1))
-
+    # dtA and dtB contain the distance from each pixel
+    # to the nearest active pixel in imgA and imgB, respectively.
+    # We only care about the distances from imgA to imgB and vice
+    # versa, so we'll pull those out by using those images as logical
+    # masks into the distance arrays.
+    dAB = _reduce(d.inner_op, dtB[imgA])
+    dBA = _reduce(d.inner_op, dtA[imgB])
     _reduce(d.outer_op, (dAB, dBA))
+end
+function evaluate_dt(   d::GenericHausdorff,
+                        imgA::GenericGrayImage,
+                        imgB::GenericGrayImage,
+                        dtA::AbstractArray,
+                        dtB::AbstractArray)
+    try
+        return evaluate_dt( d,
+                            of_eltype(Bool, imgA),
+                            of_eltype(Bool, imgB),
+                            dtA,
+                            dtB)
+    catch e
+        e isa InexactError && throw(ArgumentError("Binary image is needed."))
+        rethrow(e)
+    end
 end
 
 (d::GenericHausdorff)(imgA::GenericGrayImage, imgB::GenericGrayImage) =
-    evaluate_pset(d, img2pset(imgA), img2pset(imgB))
+    evaluate_dt(d, imgA, imgB, img2dt(imgA), img2dt(imgB))
 
 # helper functions
 @doc (@doc Hausdorff)
@@ -121,25 +149,28 @@ hausdorff(imgA::GenericGrayImage, imgB::GenericGrayImage) =
 modified_hausdorff(imgA::GenericGrayImage, imgB::GenericGrayImage)  =
     ModifiedHausdorff()(imgA, imgB)
 
-# precalculate psets to accelerate computing
+# precalculate distance transforms to accelerate computing
 function pairwise(d::GenericHausdorff,
                   imgsA::AbstractVector{<:GenericGrayImage},
                   imgsB::AbstractVector{<:GenericGrayImage})
-    psetsA = [img2pset(imgA) for imgA in imgsA]
-    psetsB = [img2pset(imgB) for imgB in imgsB]
+    dtsA = [img2dt(imgA) for imgA in imgsA]
+    dtsB = [img2dt(imgB) for imgB in imgsB]
 
     m, n = length(imgsA), length(imgsB)
     D = zeros(m, n)
 
     for j=1:n
-      psetB = psetsB[j]
+      imgB = imgsB[j]
+      dtB = dtsB[j]
       for i=min(m, j+1):m
-        psetA = psetsA[i]
-        D[i,j] = evaluate_pset(d, psetA, psetB)
+        imgA = imgsA[i]
+        dtA = dtsA[i]
+        D[i,j] = evaluate_dt(d, imgA, imgB, dtA, dtB)
       end
       for i=1:min(m, j+1)
-        psetA = psetsA[i]
-        D[i,j] = evaluate_pset(d, psetA, psetB)
+        imgA = imgsA[i]
+        dtA = dtsA[i]
+        D[i,j] = evaluate_dt(d, imgA, imgB, dtA, dtB)
       end
     end
 
@@ -147,15 +178,17 @@ function pairwise(d::GenericHausdorff,
 end
 
 function pairwise(d::GenericHausdorff, imgs::AbstractVector{<:GenericGrayImage})
-    psets = [img2pset(img) for img in imgs]
+    dts = [img2dt(img) for img in imgs]
 
     n = length(imgs)
     D = zeros(n, n)
     for j=1:n
-      psetB = psets[j]
+      imgB = imgs[j]
+      dtB = dts[j]
       for i=j+1:n
-        psetA = psets[i]
-        D[i,j] = evaluate_pset(d, psetA, psetB)
+        imgA = imgs[i]
+        dtA = dts[i]
+        D[i,j] = evaluate_dt(d, imgA, imgB, dtA, dtB)
       end
       # nothing to be done to the diagonal (always zero)
       for i=1:j-1

--- a/src/hausdorff.jl
+++ b/src/hausdorff.jl
@@ -84,7 +84,14 @@ ModifiedHausdorff() = ModifiedHausdorff(MeanReduction(), MaxReduction())
 
 # convert binary image to its distance transform
 hausdorff_transform(img::AbstractArray{Bool}) = distance_transform(feature_transform(img))
-hausdorff_transform(img::GenericGrayImage) = hausdorff_transform(of_eltype(Bool, img))
+function hausdorff_transform(img::GenericGrayImage)
+  try
+      hausdorff_transform(of_eltype(Bool, img))
+  catch e
+      e isa InexactError && throw(ArgumentError("Binary image is needed."))
+      rethrow(e)
+  end
+end
 
 function evaluate_hausdorff(d::GenericHausdorff,
                             imgA::AbstractArray{Bool},

--- a/src/hausdorff.jl
+++ b/src/hausdorff.jl
@@ -1,11 +1,4 @@
 """
-    BoolImage
-
-A type representing a binary image.
-"""
-const BoolImage = AbstractArray{Bool}
-
-"""
     ReductionOperation
 
 A reduction operation on a set of values (e.g. maximum).
@@ -90,20 +83,13 @@ const ModifiedHausdorff = GenericHausdorff{MeanReduction, MaxReduction}
 ModifiedHausdorff() = ModifiedHausdorff(MeanReduction(), MaxReduction())
 
 # convert binary image to its distance transform
-const hausdorff_transform(img::BoolImage) = img |> feature_transform |> distance_transform
+const hausdorff_transform(img::AbstractArray{Bool}) = img |> feature_transform |> distance_transform
 
-function hausdorff_transform(img::GenericGrayImage)
-    try
-        return hausdorff_transform(of_eltype(Bool, img))
-    catch e
-        e isa InexactError && throw(ArgumentError("Binary image is needed."))
-        rethrow(e)
-    end
-end
+const hausdorff_transform(img::GenericGrayImage) = hausdorff_transform(of_eltype(Bool, img))
 
 function evaluate_hausdorff(d::GenericHausdorff,
-                            imgA::BoolImage,
-                            imgB::BoolImage,
+                            imgA::AbstractArray{Bool},
+                            imgB::AbstractArray{Bool},
                             dtA::AbstractArray,
                             dtB::AbstractArray)
     # trivial cases
@@ -125,11 +111,7 @@ function evaluate_hausdorff(d::GenericHausdorff,
                             dtA::AbstractArray,
                             dtB::AbstractArray)
     try
-        return evaluate_hausdorff(  d,
-                                    of_eltype(Bool, imgA),
-                                    of_eltype(Bool, imgB),
-                                    dtA,
-                                    dtB)
+        evaluate_hausdorff(d, of_eltype(Bool, imgA), of_eltype(Bool, imgB), dtA, dtB)
     catch e
         e isa InexactError && throw(ArgumentError("Binary image is needed."))
         rethrow(e)
@@ -152,8 +134,8 @@ modified_hausdorff(imgA::GenericGrayImage, imgB::GenericGrayImage)  =
 function pairwise(d::GenericHausdorff,
                   imgsA::AbstractVector{<:GenericGrayImage},
                   imgsB::AbstractVector{<:GenericGrayImage})
-    dtsA = [hausdorff_transform(imgA) for imgA in imgsA]
-    dtsB = [hausdorff_transform(imgB) for imgB in imgsB]
+    dtsA = hausdorff_transform.(imgsA)
+    dtsB = hausdorff_transform.(imgsB)
 
     m, n = length(imgsA), length(imgsB)
     D = zeros(m, n)
@@ -177,7 +159,7 @@ function pairwise(d::GenericHausdorff,
 end
 
 function pairwise(d::GenericHausdorff, imgs::AbstractVector{<:GenericGrayImage})
-    dts = [hausdorff_transform(img) for img in imgs]
+    dts = hausdorff_transform.(imgs)
 
     n = length(imgs)
     D = zeros(n, n)


### PR DESCRIPTION
Previously, the Hausdorff routines used time and memory that was quadratic in the number of active pixels in the input images. This made them impractical for large or dense images (see #56).

Here, we leverage the `distance_transform` function from `ImageMorphology` to compute the Hausdorff distance in linear time.

Limitations
------------
* Adds a dependency on `ImageMorphology`.
* Because the new algorithm operates on a dense representation of the image, it may perform worse for very large, sparse images.
* Unlike the old algorithm, this one can't be generalized to non-images.

I'm new to Julia, so I apologize in advance for any mistakes in this PR. I'd appreciate any comments or criticisms you may have!